### PR TITLE
[Feat] #11 Step 2-2

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -36,3 +36,12 @@ fastlane/readme.md
 
 # 기타 macOS 시스템 파일
 .DS_Store
+
+# Xcode 기본 무시 항목
+DerivedData/
+xcuserdata/
+.DS_Store
+
+# 개인 API 키 파일
+APIKeys.plist
+

--- a/BookSearch-Advance/BookSearch-Advance.xcodeproj/project.pbxproj
+++ b/BookSearch-Advance/BookSearch-Advance.xcodeproj/project.pbxproj
@@ -8,10 +8,14 @@
 
 /* Begin PBXBuildFile section */
 		0C32F1B22EB0698100879067 /* SnapKit in Frameworks */ = {isa = PBXBuildFile; productRef = 0C32F1B12EB0698100879067 /* SnapKit */; };
+		0CFBA35A2EB34C69004A50BB /* APIKeys.plist in Resources */ = {isa = PBXBuildFile; fileRef = 0CFBA3592EB34C69004A50BB /* APIKeys.plist */; };
+		0CFBA35C2EB34E35004A50BB /* Secret.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0CFBA35B2EB34E35004A50BB /* Secret.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
 		0CD99ABF2EAF9159001B6F3A /* BookSearch-Advance.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = "BookSearch-Advance.app"; sourceTree = BUILT_PRODUCTS_DIR; };
+		0CFBA3592EB34C69004A50BB /* APIKeys.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = APIKeys.plist; sourceTree = "<group>"; };
+		0CFBA35B2EB34E35004A50BB /* Secret.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Secret.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFileSystemSynchronizedBuildFileExceptionSet section */
@@ -50,6 +54,8 @@
 		0CD99AB62EAF9159001B6F3A = {
 			isa = PBXGroup;
 			children = (
+				0CFBA35B2EB34E35004A50BB /* Secret.swift */,
+				0CFBA3592EB34C69004A50BB /* APIKeys.plist */,
 				0CD99AC12EAF9159001B6F3A /* BookSearch-Advance */,
 				0CD99AC02EAF9159001B6F3A /* Products */,
 			);
@@ -131,6 +137,7 @@
 			isa = PBXResourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				0CFBA35A2EB34C69004A50BB /* APIKeys.plist in Resources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -141,6 +148,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				0CFBA35C2EB34E35004A50BB /* Secret.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/BookSearch-Advance/BookSearch-Advance/BookSearchViewController.swift
+++ b/BookSearch-Advance/BookSearch-Advance/BookSearchViewController.swift
@@ -8,7 +8,18 @@
 import UIKit
 import SnapKit
 
-// 첫 번째 탭 화면: 책 검색 화면
+// MARK: - Kakao API 응답 모델
+struct KakaoBookResponse: Codable {
+    let documents: [BookDocument]
+}
+
+struct BookDocument: Codable {
+    let title: String
+    let contents: String
+    let thumbnail: String?
+}
+
+// MARK: - 책 검색 화면
 class BookSearchViewController: UIViewController {
     
     // 검색창
@@ -25,24 +36,15 @@ class BookSearchViewController: UIViewController {
         return tableView
     }()
     
-    private var searchResults: [String] = []
+    // ✅ 이제 문자열이 아니라 BookDocument 배열로 변경
+    private var searchResults: [BookDocument] = []
     
-    private let allBooks = [
-        "해리포터",
-        "해리포터2",
-        "해리포터3",
-        "해리포터4"
-    ]
-    
-   
     override func viewDidLoad() {
         super.viewDidLoad()
         view.backgroundColor = .systemBackground
-        title = "검색" // 네비게이션 상단 제목
-        
+        title = "검색"
         setupLayout()
         setupDelegate()
-        
     }
     
     override func viewWillAppear(_ animated: Bool) {
@@ -50,14 +52,10 @@ class BookSearchViewController: UIViewController {
         searchBar.delegate = self
     }
     
-    
-    // 오토레이아웃 설정
+    // MARK: - 오토레이아웃 설정
     private func setupLayout() {
         view.addSubview(searchBar)
         view.addSubview(tableView)
-        
-        searchBar.translatesAutoresizingMaskIntoConstraints = false
-        tableView.translatesAutoresizingMaskIntoConstraints = false
         
         searchBar.snp.makeConstraints {
             $0.top.equalTo(view.safeAreaLayoutGuide.snp.top)
@@ -74,54 +72,224 @@ class BookSearchViewController: UIViewController {
     private func setupDelegate() {
         tableView.dataSource = self
         tableView.delegate = self
-        
     }
     
+    // MARK: - Kakao API 호출 함수
+    private func fetchBooks(query: String) {
+        // plist에서 API 키 불러오기
+        let apiKey = Secret.kakaoAPIKey
+        
+        // 검색어를 URL에 넣기
+        let encodedQuery = query.addingPercentEncoding(withAllowedCharacters: .urlQueryAllowed) ?? query
+        let urlString = "https://dapi.kakao.com/v3/search/book?query=\(encodedQuery)"
+        
+        guard let url = URL(string: urlString) else { return }
+        
+        var request = URLRequest(url: url)
+        request.setValue(apiKey, forHTTPHeaderField: "Authorization")
+        
+        // 네트워크 요청
+        URLSession.shared.dataTask(with: request) { [weak self] data, response, error in
+            guard let self = self, let data = data, error == nil else { return }
+            do {
+                let decoded = try JSONDecoder().decode(KakaoBookResponse.self, from: data)
+                DispatchQueue.main.async {
+                    self.searchResults = decoded.documents
+                    self.tableView.reloadData()
+                }
+            } catch {
+                print("디코딩 오류:", error)
+            }
+        }.resume()
+    }
 }
 
-// UISearchBarDelegate (검색 기능)
+// MARK: - UISearchBarDelegate
 extension BookSearchViewController: UISearchBarDelegate {
-    func searchBarTextDidEndEditing(_ searchBar: UISearchBar) {
-        print("✅ searchBarTextDidEndEditing 실행됨")
-        guard let keyword = searchBar.text?.lowercased(), !keyword.isEmpty else { return }
-        
-        searchResults = allBooks.filter { $0.lowercased().contains(keyword) }
-        print("검색 결과:", searchResults)
-        
-        tableView.reloadData()
-        searchBar.resignFirstResponder() // 키보드 내리기
-        
+    func searchBarSearchButtonClicked(_ searchBar: UISearchBar) {
+        guard let keyword = searchBar.text, !keyword.isEmpty else { return }
+        fetchBooks(query: keyword)
+        searchBar.resignFirstResponder()
     }
 }
 
-
-
-// 테이블 뷰 데이터 설정 (추후 변경 예정)
+// MARK: - UITableView
 extension BookSearchViewController: UITableViewDataSource, UITableViewDelegate {
-    
-    
-    // 섹션 당 셀 개수
     func tableView(_ tableView: UITableView, numberOfRowsInSection section: Int) -> Int {
         return searchResults.count
     }
     
-    // 셀 내용 구성
     func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
         let cell = tableView.dequeueReusableCell(withIdentifier: "BookCell", for: indexPath)
-        cell.textLabel?.text = searchResults[indexPath.row] // 첵 제목 표시
+        let book = searchResults[indexPath.row]
+        cell.textLabel?.text = book.title
+            .replacingOccurrences(of: "<b>", with: "")
+            .replacingOccurrences(of: "</b>", with: "")
         return cell
     }
     
-    // 셀 탭 시 동작(책 상세 화면 모달로 띄우기)
     func tableView(_ tableView: UITableView, didSelectRowAt indexPath: IndexPath) {
         tableView.deselectRow(at: indexPath, animated: true)
         
-        let selectedTitle = searchResults[indexPath.row]
-        let detaiVC = BookDetailViewController()
-        detaiVC.book = Book(title: selectedTitle, description: "검색 결과 예시 설명")
-        detaiVC.modalPresentationStyle = .pageSheet // 아래에서 위로 올라오는 시트형 모달
-        present(detaiVC, animated: true)
+        let selectedBook = searchResults[indexPath.row]
+        let detailVC = BookDetailViewController()
+        detailVC.book = Book(
+            title: selectedBook.title.replacingOccurrences(of: "<b>", with: "").replacingOccurrences(of: "</b>", with: ""),
+            description: selectedBook.contents
+        )
+        detailVC.modalPresentationStyle = .pageSheet
+        present(detailVC, animated: true)
     }
 }
 
 
+//import UIKit
+//import SnapKit
+//
+//// 첫 번째 탭 화면: 책 검색 화면
+//class BookSearchViewController: UIViewController {
+//    
+//    // 검색창
+//    private let searchBar: UISearchBar = {
+//        let searchBar = UISearchBar()
+//        searchBar.placeholder = "검색어를 입력하세요"
+//        return searchBar
+//    }()
+//    
+//    // 책 목록을 보여줄 테이블 뷰
+//    private let tableView: UITableView = {
+//        let tableView = UITableView()
+//        tableView.register(UITableViewCell.self, forCellReuseIdentifier: "BookCell")
+//        return tableView
+//    }()
+//    
+//    private var searchResults: [String] = []
+//    
+//    private let allBooks = [
+//        "해리포터",
+//        "해리포터2",
+//        "해리포터3",
+//        "해리포터4"
+//    ]
+//    
+//   
+//    override func viewDidLoad() {
+//        super.viewDidLoad()
+//        view.backgroundColor = .systemBackground
+//        title = "검색" // 네비게이션 상단 제목
+//        
+//        setupLayout()
+//        setupDelegate()
+//        
+//    }
+//    
+//    override func viewWillAppear(_ animated: Bool) {
+//        super.viewWillAppear(animated)
+//        searchBar.delegate = self
+//    }
+//    
+//    
+//    // 오토레이아웃 설정
+//    private func setupLayout() {
+//        view.addSubview(searchBar)
+//        view.addSubview(tableView)
+//        
+//        searchBar.translatesAutoresizingMaskIntoConstraints = false
+//        tableView.translatesAutoresizingMaskIntoConstraints = false
+//        
+//        searchBar.snp.makeConstraints {
+//            $0.top.equalTo(view.safeAreaLayoutGuide.snp.top)
+//            $0.leading.trailing.equalToSuperview()
+//            $0.height.equalTo(44)
+//        }
+//        
+//        tableView.snp.makeConstraints {
+//            $0.top.equalTo(searchBar.snp.bottom)
+//            $0.leading.trailing.bottom.equalToSuperview()
+//        }
+//    }
+//    
+//    private func setupDelegate() {
+//        tableView.dataSource = self
+//        tableView.delegate = self
+//        
+//    }
+//    
+//}
+//
+//private func fetchBooks(query: String) {
+//    // plist에서 API 키 불러오기
+//    let apiKey = Secret.kakaoAPIKey
+//    
+//    // 검색어를 URL에 넣기
+//    let encodedQuery = query.addingPercentEncoding(withAllowedCharacters: .urlQueryAllowed)
+//    let urlString = "https://dapi.kakao.com/v3/search/book?query=\(encodedQuery)"
+//    
+//    guard let url = URL(string: urlString) else { return }
+//    
+//    // 요청 생성
+//    var request = URLRequest(url: url)
+//    request.setValue(apiKey, forHTTPHeaderField: "Authorization")
+//    
+//    // 네트워크 요청 보내기
+//    URLSession.shared.dataTask(with: request) { [weak self] data, response, error in
+//        guard let self = self, let data = data, error == nil else { return }
+//        do {
+//            let decoded = try JSONDecoder().decode(KakakoBookResponse.self, from: data)
+//            dispatchQueue.main.async {
+//                
+//                self.searchResults = decoded.documents
+//                self.tableView.reloadData()
+//            }
+//        } catch {
+//            print("디코딩 오류", error)
+//        }
+//    }.resume()
+//}
+//
+//// UISearchBarDelegate (검색 기능)
+//extension BookSearchViewController: UISearchBarDelegate {
+//    func searchBarTextDidEndEditing(_ searchBar: UISearchBar) {
+//        print("✅ searchBarTextDidEndEditing 실행됨")
+//        guard let keyword = searchBar.text?.lowercased(), !keyword.isEmpty else { return }
+//        
+//        searchResults = allBooks.filter { $0.lowercased().contains(keyword) }
+//        print("검색 결과:", searchResults)
+//        
+//        tableView.reloadData()
+//        searchBar.resignFirstResponder() // 키보드 내리기
+//        
+//    }
+//}
+//
+//
+//
+//// 테이블 뷰 데이터 설정 (추후 변경 예정)
+//extension BookSearchViewController: UITableViewDataSource, UITableViewDelegate {
+//    
+//    
+//    // 섹션 당 셀 개수
+//    func tableView(_ tableView: UITableView, numberOfRowsInSection section: Int) -> Int {
+//        return searchResults.count
+//    }
+//    
+//    // 셀 내용 구성
+//    func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
+//        let cell = tableView.dequeueReusableCell(withIdentifier: "BookCell", for: indexPath)
+//        cell.textLabel?.text = searchResults[indexPath.row] // 첵 제목 표시
+//        return cell
+//    }
+//    
+//    // 셀 탭 시 동작(책 상세 화면 모달로 띄우기)
+//    func tableView(_ tableView: UITableView, didSelectRowAt indexPath: IndexPath) {
+//        tableView.deselectRow(at: indexPath, animated: true)
+//        
+//        let selectedTitle = searchResults[indexPath.row]
+//        let detaiVC = BookDetailViewController()
+//        detaiVC.book = Book(title: selectedTitle, description: "검색 결과 예시 설명")
+//        detaiVC.modalPresentationStyle = .pageSheet // 아래에서 위로 올라오는 시트형 모달
+//        present(detaiVC, animated: true)
+//    }
+//}
+//
+//

--- a/BookSearch-Advance/File.txt
+++ b/BookSearch-Advance/File.txt
@@ -1,0 +1,16 @@
+검색 기능
+사용자는 서치바를 사용하여 책을 검색할 수 있습니다.
+검색(입력완료)를 누르면, 검색 결과 리스트에 책 목록이 등장합니다.
+검색에는, 또한 카카오 책 검색 REST API 를 이용합니다.
+Kakao Developers 검색 제품의  책 검색 기능을 사용합니다.
+https://developers.kakao.com/docs/latest/ko/daum-search/dev-guide#search-book
+간단한 Swift 예제 코드
+    let url = URL(string: "https://dapi.kakao.com/v3/search/book?query=세이노")!
+    
+    var request = URLRequest(url: url)
+    
+    request.allHTTPHeaderFields = ["Authorization": "KakaoAK <이 곳에 RESTAPI Key 를 넣으세요.>"]
+    
+    URLSession.shared.dataTask(with: request) { data, _, _ in
+      print(String(data: data!, encoding: .utf8))
+    }.resume()

--- a/BookSearch-Advance/Secret.swift
+++ b/BookSearch-Advance/Secret.swift
@@ -1,0 +1,27 @@
+//
+//  Secret.swift
+//  BookSearch-Advance
+//
+//  Created by 김리하 on 10/30/25.
+//
+
+import Foundation
+
+
+enum Secret {
+    static var kakaoAPIKey: String {
+        guard
+            let path = Bundle.main.path(forResource: "APIKeys", ofType: "plist"),
+            let dict = NSDictionary(contentsOfFile: path) as? [String: Any],
+            let key = dict["KAKAO_API_KEY"] as? String,
+            !key.isEmpty
+        else {
+            #if DEBUG
+            fatalError("KAKAO_API_KEY가 비어있거나 APIKey.plist를 찾을 수 없습니다. APIKeys.sample.plist를 복사해 채워주세요.")
+            #else
+            return ""
+            #endif
+        }
+        return key
+    }
+}


### PR DESCRIPTION
<img width="498" height="943" alt="스크린샷 2025-10-30 19 30 45" src="https://github.com/user-attachments/assets/5a883589-3765-450d-80b4-5830ee504aff" />

API 키 숨김처리 완료~
밑에 주석처리된 건 다음 거에서 지울 예정...(혹시 몰라 살려뒀는데 지우는 거 까먹음)

## 🌐 Kakao REST API 관련 명령어
- `URL(string:)` : Kakao REST API 주소를 URL 객체로 변환
-  `URLRequest(url:)` : 요청 객체 생성해서 헤더 설정 및 통신 준비용
-  `DispatchQueue.main.async { ... } `: UI 갱신은 메인 스레드에서 처리해야 해서 사용
-  `guard let` : 옵셔널 안전하게 해제하기 위해 사용


